### PR TITLE
hasPermission on NeoForge: return false if permission is not registered

### DIFF
--- a/cloud-fabric/src/main/java/org/incendo/cloud/fabric/FabricServerCommandManager.java
+++ b/cloud-fabric/src/main/java/org/incendo/cloud/fabric/FabricServerCommandManager.java
@@ -124,6 +124,9 @@ public final class FabricServerCommandManager<C> extends FabricCommandManager<C,
      */
     @Override
     public boolean hasPermission(final @NonNull C sender, final @NonNull String permission) {
+        if (permission.isEmpty()) {
+            return true;
+        }
         final CommandSourceStack source = this.senderMapper().reverse(sender);
         return Permissions.check(source, permission, source.getServer().getOperatorUserPermissionLevel());
     }

--- a/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/NeoForgeServerCommandManager.java
+++ b/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/NeoForgeServerCommandManager.java
@@ -25,6 +25,7 @@ package org.incendo.cloud.neoforge;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.concurrent.ExecutionException;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
@@ -91,9 +92,21 @@ public final class NeoForgeServerCommandManager<C> extends NeoForgeCommandManage
         ModdedParserMappings.registerServer(this);
     }
 
+    /**
+     * Check if the command sender has the required permission. If the permission node is
+     * empty, this should return {@code true}
+     *
+     * @param sender     Command sender
+     * @param permission Permission node
+     * @return {@code true} if the sender has the permission, else {@code false}
+     * @throws PermissionNotRegisteredException if the permission is not registered to NeoForge
+     */
     @SuppressWarnings({"unchecked", "ReferenceEquality"})
     @Override
     public boolean hasPermission(final @NonNull C sender, final @NonNull String permission) {
+        if (permission.isEmpty()) {
+            return true;
+        }
         final CommandSourceStack source = this.senderMapper().reverse(sender);
         if (source.isPlayer()) {
             final PermissionNode<Boolean> node;
@@ -101,22 +114,18 @@ public final class NeoForgeServerCommandManager<C> extends NeoForgeCommandManage
                 node = this.permissionNodeCache.get(permission, () -> (PermissionNode<Boolean>) PermissionAPI.getRegisteredNodes().stream()
                     .filter(n -> n.getNodeName().equals(permission) && n.getType() == PermissionTypes.BOOLEAN)
                     .findFirst()
-                    .orElseThrow(PermissionNodeNotFoundException::new));
-            } catch (final ExecutionException e) {
-                if (e.getCause() instanceof PermissionNodeNotFoundException) {
-                    return false; // permission node not found (not registered)
+                    .orElseThrow(() -> new PermissionNotRegisteredException(permission)));
+            } catch (final UncheckedExecutionException e) {
+                if (e.getCause() instanceof PermissionNotRegisteredException notRegisteredException) {
+                    // PermissionNotRegisteredException is unchecked, so Cache#get will throw UncheckedExecutionException
+                    throw notRegisteredException;
                 }
-                throw new RuntimeException("Exception location permission node", e);
+                throw new RuntimeException("Exception location permission node " + permission, e);
+            } catch (final ExecutionException e) {
+                throw new RuntimeException("Exception location permission node " + permission, e);
             }
             return PermissionAPI.getPermission(source.getPlayer(), node);
         }
         return source.hasPermission(source.getServer().getOperatorUserPermissionLevel());
-    }
-
-    /**
-     * Custom exception used to indicate that the permissionNodeCache loader could not find a permission node
-     */
-    private static final class PermissionNodeNotFoundException extends Exception {
-
     }
 }

--- a/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/PermissionNotRegisteredException.java
+++ b/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/PermissionNotRegisteredException.java
@@ -1,0 +1,46 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.neoforge;
+
+/**
+ * Exception thrown when a permission lookup is performed with a permission not registered to NeoForge.
+ */
+public final class PermissionNotRegisteredException extends RuntimeException {
+
+    private final String permission;
+
+    PermissionNotRegisteredException(String permission) {
+        super(permission + " is not registered to NeoForge.");
+        this.permission = permission;
+    }
+
+    /**
+     * Returns the unregistered permission
+     *
+     * @return the unregistered permission
+     */
+    public String permission() {
+        return this.permission;
+    }
+}

--- a/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/PermissionNotRegisteredException.java
+++ b/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/PermissionNotRegisteredException.java
@@ -23,6 +23,8 @@
 //
 package org.incendo.cloud.neoforge;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Exception thrown when a permission lookup is performed with a permission not registered to NeoForge.
  */
@@ -30,7 +32,7 @@ public final class PermissionNotRegisteredException extends RuntimeException {
 
     private final String permission;
 
-    PermissionNotRegisteredException(String permission) {
+    PermissionNotRegisteredException(final @NonNull String permission) {
         super(permission + " is not registered to NeoForge.");
         this.permission = permission;
     }
@@ -40,7 +42,7 @@ public final class PermissionNotRegisteredException extends RuntimeException {
      *
      * @return the unregistered permission
      */
-    public String permission() {
+    public @NonNull String permission() {
         return this.permission;
     }
 }


### PR DESCRIPTION
`NeoForgeServerCommandManager#hasPermission` currently throws if the permission is not registered to the server. This isn't really in line with the other cloud implementations, and makes it cumbersome to use this method in an abstracted context.

Guava cache loader can't return a null value, so instead we throw a custom exception in order to return false.

- [ ] test it

