### PR TITLE
Build against 1.21.3

### DIFF
--- a/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
+++ b/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
@@ -41,6 +41,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.item.ItemInput;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
@@ -49,6 +50,7 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.Vec3;
@@ -121,7 +123,7 @@ public final class FabricExample implements ModInitializer {
                 ctx.sender().sendSuccess(() -> Component.literal("Yes, the biome ")
                     .append(Component.literal(
                             ctx.sender().registryAccess()
-                                .registryOrThrow(Registries.BIOME)
+                                .lookupOrThrow(Registries.BIOME)
                                 .getKey(ctx.get("biome")).toString())
                         .withStyle(ChatFormatting.DARK_PURPLE, ChatFormatting.BOLD))
                     .append(Component.literal(" is pretty cool"))
@@ -269,8 +271,10 @@ public final class FabricExample implements ModInitializer {
             .handler(ctx -> {
                 final MultipleEntitySelector selector = ctx.get("targets");
                 final Vec3 location = ctx.<Coordinates>get("location").position();
-                selector.values().forEach(target ->
-                    target.teleportToWithTicket(location.x(), location.y(), location.z()));
+                selector.values().forEach(target -> {
+                    target.placePortalTicket(new BlockPos(Mth.floor(location.x()), Mth.floor(location.y()), Mth.floor(location.z())));
+                    target.teleportTo(location.x(), location.y(), location.z());
+                });
             }));
 
         manager.command(base.literal("signed")
@@ -309,7 +313,8 @@ public final class FabricExample implements ModInitializer {
                 }
                 final Vec3 vec = ctx.<ColumnCoordinates>get("chunk_position").position();
                 final ChunkPos pos = new ChunkPos((int) vec.x(), (int) vec.z());
-                player.teleportToWithTicket(pos.getMinBlockX(), 128, pos.getMinBlockZ());
+                player.placePortalTicket(new BlockPos(pos.getMinBlockX(), 128, pos.getMinBlockZ()));
+                player.teleportTo(pos.getMinBlockX(), 128, pos.getMinBlockZ());
             }));
     }
 }

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/parser/RegistryEntryParser.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/parser/RegistryEntryParser.java
@@ -136,7 +136,7 @@ public final class RegistryEntryParser<C, V> implements ArgumentParser<C, V>, Bl
             return ArgumentParseResult.failure(new IllegalArgumentException("Unknown registry " + this.registryIdent));
         }
 
-        final V entry = registry.get(key);
+        final V entry = registry.getValue(key);
         if (entry == null) {
             return ArgumentParseResult.failure(new UnknownEntryException(commandContext, key, this.registryIdent));
         }
@@ -146,7 +146,7 @@ public final class RegistryEntryParser<C, V> implements ArgumentParser<C, V>, Bl
 
     private Registry<V> resolveRegistry(final CommandContext<C> ctx) {
         final SharedSuggestionProvider reverseMapped = ctx.get(ModdedCommandContextKeys.SHARED_SUGGESTION_PROVIDER);
-        return reverseMapped.registryAccess().registry(this.registryIdent).orElse(null);
+        return reverseMapped.registryAccess().lookup(this.registryIdent).orElse(null);
     }
 
     @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,10 @@ cloudMinecraft = "2.0.0-beta.10"
 
 immutables = "2.10.1"
 
-minecraft = "1.20.6"
+minecraft = "1.21.3"
 fabricLoader = "0.16.9"
-fabricApi = "0.100.8+1.20.6"
-fabricPermissionsApi = "0.3.1"
+fabricApi = "0.110.0+1.21.3"
+fabricPermissionsApi = "0.3.3"
 
 [libraries]
 cloud-build-logic = { module = "org.incendo:cloud-build-logic", version.ref = "cloud-build-logic" }
@@ -39,7 +39,7 @@ fabricApi-networking-api-v1 = { module = "net.fabricmc.fabric-api:fabric-network
 fabricApi-lifecycle-events-v1 = { module = "net.fabricmc.fabric-api:fabric-lifecycle-events-v1" }
 fabricPermissionsApi = { group = "me.lucko", name = "fabric-permissions-api", version.ref = "fabricPermissionsApi" }
 
-neoForge = "net.neoforged:neoforge:20.6.121"
+neoForge = "net.neoforged:neoforge:21.3.56"
 
 [plugins]
 cloud-buildLogic-spotless = { id = "org.incendo.cloud-build-logic.spotless", version.ref = "cloud-build-logic" }


### PR DESCRIPTION
This makes the RegistryEntryParser break on older versions on NeoForge

Should still work on fabric due to intermediary