### PR TITLE
adventure-platform-mod 6.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 .idea/
 
 run/
+
+.kotlin/

--- a/cloud-fabric/build.gradle.kts
+++ b/cloud-fabric/build.gradle.kts
@@ -99,6 +99,8 @@ dependencies {
     localRuntime(libs.cloud.minecraft.signed.arguments)
     modLocalRuntime(libs.adventureFabric)
     "modTestmodImplementation"(libs.adventureFabric)
+    "testmodImplementation"(libs.cloud.minecraft.extras)
+    localRuntime(libs.cloud.minecraft.extras)
 }
 
 val testmodJar by tasks.registering(Jar::class) {

--- a/cloud-fabric/build.gradle.kts
+++ b/cloud-fabric/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     api(libs.cloud.brigadier)
 
     compileOnly(libs.cloud.minecraft.signed.arguments)
-    modCompileOnly(libs.adventureFabric)
 
     offlineLinkedJavadoc(project(":cloud-minecraft-modded-common"))
     localRuntime(project(":cloud-minecraft-modded-common"))
@@ -92,9 +91,14 @@ val testmod: SourceSet by sourceSets.creating {
     dependencies.add(implementationConfigurationName, main.output)
 }
 
+loom {
+    createRemapConfigurations(testmod)
+}
+
 dependencies {
     localRuntime(libs.cloud.minecraft.signed.arguments)
     modLocalRuntime(libs.adventureFabric)
+    "modTestmodImplementation"(libs.adventureFabric)
 }
 
 val testmodJar by tasks.registering(Jar::class) {

--- a/cloud-fabric/src/main/java/org/incendo/cloud/fabric/internal/CloudFabricEntrypoint.java
+++ b/cloud-fabric/src/main/java/org/incendo/cloud/fabric/internal/CloudFabricEntrypoint.java
@@ -1,0 +1,49 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.fabric.internal;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.incendo.cloud.minecraft.modded.internal.AdventureSupport;
+
+@API(status = API.Status.INTERNAL)
+@DefaultQualifier(NonNull.class)
+public final class CloudFabricEntrypoint implements ModInitializer {
+
+    @Override
+    public void onInitialize() {
+        if (FabricLoader.getInstance().isModLoaded("adventure-platform-fabric")) {
+            ServerLifecycleEvents.SERVER_STARTING.register(AdventureSupport.get()::setupServer);
+            ServerLifecycleEvents.SERVER_STOPPED.register(AdventureSupport.get()::removeServer);
+            if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+                AdventureSupport.get().setupClient();
+            }
+        }
+    }
+}

--- a/cloud-fabric/src/main/java/org/incendo/cloud/fabric/internal/CloudFabricEntrypoint.java
+++ b/cloud-fabric/src/main/java/org/incendo/cloud/fabric/internal/CloudFabricEntrypoint.java
@@ -23,6 +23,7 @@
 //
 package org.incendo.cloud.fabric.internal;
 
+import java.util.Objects;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -36,13 +37,21 @@ import org.incendo.cloud.minecraft.modded.internal.AdventureSupport;
 @DefaultQualifier(NonNull.class)
 public final class CloudFabricEntrypoint implements ModInitializer {
 
+    @SuppressWarnings("EmptyCatch")
     @Override
     public void onInitialize() {
         if (FabricLoader.getInstance().isModLoaded("adventure-platform-fabric")) {
-            ServerLifecycleEvents.SERVER_STARTING.register(AdventureSupport.get()::setupServer);
-            ServerLifecycleEvents.SERVER_STOPPED.register(AdventureSupport.get()::removeServer);
-            if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
-                AdventureSupport.get().setupClient();
+            try {
+                Objects.requireNonNull(
+                    Class.forName("net.kyori.adventure.platform.modcommon.MinecraftAudiences").getName()
+                );
+
+                ServerLifecycleEvents.SERVER_STARTING.register(AdventureSupport.get()::setupServer);
+                ServerLifecycleEvents.SERVER_STOPPED.register(AdventureSupport.get()::removeServer);
+                if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+                    AdventureSupport.get().setupClient();
+                }
+            } catch (final ClassNotFoundException ignored) {
             }
         }
     }

--- a/cloud-fabric/src/main/resources/META-INF/services/org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper$SignedStringFactory
+++ b/cloud-fabric/src/main/resources/META-INF/services/org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper$SignedStringFactory
@@ -1,1 +1,0 @@
-org.incendo.cloud.fabric.internal.FabricSignedStringFactory

--- a/cloud-fabric/src/main/resources/fabric.mod.json
+++ b/cloud-fabric/src/main/resources/fabric.mod.json
@@ -15,7 +15,8 @@
 
   "entrypoints": {
     "main": [
-      "org.incendo.cloud.fabric.internal.LateRegistrationCatcher"
+      "org.incendo.cloud.fabric.internal.LateRegistrationCatcher",
+      "org.incendo.cloud.fabric.internal.CloudFabricEntrypoint"
     ]
   },
 

--- a/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
+++ b/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
@@ -35,8 +35,8 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.fabricmc.loader.api.metadata.Person;
 import net.kyori.adventure.chat.ChatType;
 import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.platform.fabric.AdventureCommandSourceStack;
-import net.kyori.adventure.platform.fabric.FabricServerAudiences;
+import net.kyori.adventure.platform.modcommon.AdventureCommandSourceStack;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
@@ -281,7 +281,7 @@ public final class FabricExample implements ModInitializer {
             .required("message", signedGreedyStringParser())
             .handler(ctx -> {
                 final AdventureCommandSourceStack audience =
-                    FabricServerAudiences.of(ctx.sender().getServer()).audience(ctx.sender());
+                    MinecraftServerAudiences.of(ctx.sender().getServer()).audience(ctx.sender());
 
                 final SignedString message = ctx.get("message");
 

--- a/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
+++ b/cloud-fabric/src/testmod/java/org/incendo/cloud/fabric/testmod/FabricExample.java
@@ -27,8 +27,10 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
@@ -61,9 +63,9 @@ import org.incendo.cloud.execution.ExecutionCoordinator;
 import org.incendo.cloud.fabric.FabricServerCommandManager;
 import org.incendo.cloud.fabric.testmod.mixin.GiveCommandAccess;
 import org.incendo.cloud.key.CloudKey;
+import org.incendo.cloud.minecraft.extras.MinecraftExceptionHandler;
 import org.incendo.cloud.minecraft.modded.data.Coordinates;
 import org.incendo.cloud.minecraft.modded.data.Coordinates.ColumnCoordinates;
-import org.incendo.cloud.minecraft.modded.data.MultipleEntitySelector;
 import org.incendo.cloud.minecraft.modded.data.MultiplePlayerSelector;
 import org.incendo.cloud.minecraft.modded.parser.NamedColorParser;
 import org.incendo.cloud.minecraft.modded.parser.RegistryEntryParser;
@@ -88,6 +90,11 @@ public final class FabricExample implements ModInitializer {
         // Create a commands manager. We'll use native command source types for this.
         final FabricServerCommandManager<CommandSourceStack> manager =
             FabricServerCommandManager.createNative(ExecutionCoordinator.simpleCoordinator());
+
+        AtomicReference<MinecraftServerAudiences> audiences = new AtomicReference<>();
+        ServerLifecycleEvents.SERVER_STARTING.register((server) -> audiences.set(MinecraftServerAudiences.of(server)));
+        MinecraftExceptionHandler.<CommandSourceStack>create(stack -> audiences.get().audience(stack))
+            .registerTo(manager);
 
         final Command.Builder<CommandSourceStack> base = manager.commandBuilder("cloudtest");
 
@@ -224,7 +231,8 @@ public final class FabricExample implements ModInitializer {
                 .map(Suggestion::suggestion)
                 .collect(Collectors.toList())))
             .parser((commandContext, commandInput) -> {
-                final ModMetadata meta = FabricLoader.getInstance().getModContainer(commandInput.readString())
+                final String s = commandInput.readString();
+                final ModMetadata meta = FabricLoader.getInstance().getModContainer(s)
                     .map(ModContainer::getMetadata)
                     .orElse(null);
                 if (meta != null) {
@@ -232,7 +240,7 @@ public final class FabricExample implements ModInitializer {
                 }
                 return ArgumentParseResult.failure(new IllegalArgumentException(String.format(
                     "No mod with id '%s'",
-                    commandInput.peek()
+                    s
                 )));
             })
             .build();
@@ -269,7 +277,7 @@ public final class FabricExample implements ModInitializer {
             .required("targets", multiplePlayerSelectorParser())
             .required("location", vec3Parser(false))
             .handler(ctx -> {
-                final MultipleEntitySelector selector = ctx.get("targets");
+                final MultiplePlayerSelector selector = ctx.get("targets");
                 final Vec3 location = ctx.<Coordinates>get("location").position();
                 selector.values().forEach(target -> {
                     target.placePortalTicket(new BlockPos(Mth.floor(location.x()), Mth.floor(location.y()), Mth.floor(location.z())));

--- a/cloud-minecraft-modded-common/build.gradle.kts
+++ b/cloud-minecraft-modded-common/build.gradle.kts
@@ -14,8 +14,7 @@ neoForge {
 }
 
 dependencies {
-    // todo: depend on common when deps fixed
-    compileOnly(libs.adventureFabric)
+    compileOnly(libs.adventureMod)
 
     compileOnly(libs.cloud.minecraft.extras)
 }

--- a/cloud-minecraft-modded-common/build.gradle.kts
+++ b/cloud-minecraft-modded-common/build.gradle.kts
@@ -13,6 +13,10 @@ neoForge {
     }
 }
 
+dependencies {
+    compileOnly(libs.adventureFabric)
+}
+
 tasks.withType(AbstractRemapJarTask::class).configureEach {
     targetNamespace = "named"
 }

--- a/cloud-minecraft-modded-common/build.gradle.kts
+++ b/cloud-minecraft-modded-common/build.gradle.kts
@@ -15,6 +15,8 @@ neoForge {
 
 dependencies {
     compileOnly(libs.adventureFabric)
+
+    compileOnly(libs.cloud.minecraft.extras)
 }
 
 tasks.withType(AbstractRemapJarTask::class).configureEach {

--- a/cloud-minecraft-modded-common/build.gradle.kts
+++ b/cloud-minecraft-modded-common/build.gradle.kts
@@ -14,6 +14,7 @@ neoForge {
 }
 
 dependencies {
+    // todo: depend on common when deps fixed
     compileOnly(libs.adventureFabric)
 
     compileOnly(libs.cloud.minecraft.extras)

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
@@ -93,9 +93,8 @@ public final class AdventureSupport {
         final @Nullable MinecraftAudiences server = this.server;
         if (server == null) {
             return Objects.requireNonNull(this.client, "No audiences present");
-        } else {
-            return this.server;
         }
+        return server;
     }
 
     /**

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
@@ -54,6 +54,7 @@ public final class AdventureSupport {
         try {
             ComponentMessageThrowableConverter.setup(this);
         } catch (final LinkageError ignored) {
+            // cloud-minecraft-extras not present
         }
     }
 

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/AdventureSupport.java
@@ -1,0 +1,108 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.minecraft.modded.internal;
+
+import java.util.Objects;
+import net.kyori.adventure.platform.modcommon.MinecraftAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftClientAudiences;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
+import net.minecraft.server.MinecraftServer;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+@API(status = API.Status.INTERNAL)
+@DefaultQualifier(NonNull.class)
+public final class AdventureSupport {
+    private static final AdventureSupport INSTANCE;
+
+    static {
+        INSTANCE = new AdventureSupport();
+        INSTANCE.setupConverter();
+    }
+
+    private @Nullable MinecraftAudiences client;
+    private @Nullable MinecraftAudiences server;
+
+    private AdventureSupport() {
+    }
+
+    @SuppressWarnings("EmptyCatch")
+    private void setupConverter() {
+        try {
+            ComponentMessageThrowableConverter.setup(this);
+        } catch (final LinkageError ignored) {
+        }
+    }
+
+    /**
+     * Set up the client audience.
+     */
+    public void setupClient() {
+        this.client = MinecraftClientAudiences.of();
+    }
+
+    /**
+     * Set up the server audience.
+     *
+     * @param server server
+     */
+    public void setupServer(final MinecraftServer server) {
+        this.server = MinecraftServerAudiences.of(server);
+    }
+
+    /**
+     * Shutdown the server audience.
+     *
+     * @param server server
+     */
+    @SuppressWarnings("unused")
+    public void removeServer(final MinecraftServer server) {
+        this.server = null;
+    }
+
+    /**
+     * Get the MinecraftAudiences instance.
+     *
+     * @return audiences
+     */
+    public MinecraftAudiences audiences() {
+        final @Nullable MinecraftAudiences server = this.server;
+        if (server == null) {
+            return Objects.requireNonNull(this.client, "No audiences present");
+        } else {
+            return this.server;
+        }
+    }
+
+    /**
+     * Returns the AdventureSupport instance.
+     *
+     * @return the instance
+     */
+    public static AdventureSupport get() {
+        return INSTANCE;
+    }
+}

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ComponentMessageThrowableConverter.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ComponentMessageThrowableConverter.java
@@ -1,0 +1,55 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.minecraft.modded.internal;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.incendo.cloud.minecraft.extras.MinecraftExceptionHandler;
+
+@API(status = API.Status.INTERNAL)
+@DefaultQualifier(NonNull.class)
+final class ComponentMessageThrowableConverter implements MinecraftExceptionHandler.ComponentMessageThrowableConverter {
+
+    private final AdventureSupport adventureSupport;
+
+    ComponentMessageThrowableConverter(final AdventureSupport adventureSupport) {
+        this.adventureSupport = adventureSupport;
+    }
+
+    static void setup(final AdventureSupport adventureSupport) {
+        MinecraftExceptionHandler.ComponentMessageThrowableConverterHolder.converter(
+            new ComponentMessageThrowableConverter(adventureSupport)
+        );
+    }
+
+    @Override
+    public Throwable maybeConvert(final Throwable thr) {
+        if (thr instanceof CommandSyntaxException cse) {
+            return (Exception) this.adventureSupport.audiences().asComponentThrowable(cse);
+        }
+        return thr;
+    }
+}

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringFactory.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringFactory.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.ChatType;
 import net.kyori.adventure.chat.SignedMessage;
-import net.kyori.adventure.platform.modcommon.impl.NonWrappingComponentSerializer;
+import net.kyori.adventure.platform.modcommon.MinecraftAudiences;
 import net.kyori.adventure.text.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
 import org.apiguardian.api.API;
@@ -42,7 +42,7 @@ public final class ModdedSignedStringFactory implements ModdedSignedStringMapper
      */
     public ModdedSignedStringFactory() {
         // Trigger service load failure when this isn't present
-        Objects.requireNonNull(NonWrappingComponentSerializer.class.getName());
+        Objects.requireNonNull(MinecraftAudiences.class.getName());
     }
 
     @Override
@@ -64,7 +64,8 @@ public final class ModdedSignedStringFactory implements ModdedSignedStringMapper
 
         @Override
         public void sendMessage(final Audience audience, final ChatType.Bound chatType, final Component unsigned) {
-            final net.minecraft.network.chat.Component nativeComponent = NonWrappingComponentSerializer.INSTANCE.serialize(unsigned);
+            final net.minecraft.network.chat.Component nativeComponent =
+                AdventureSupport.get().audiences().asNative(unsigned);
             final PlayerChatMessage playerChatMessage = this.rawSignedMessage.withUnsignedContent(nativeComponent);
             audience.sendMessage(cast(playerChatMessage), chatType);
         }

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringFactory.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringFactory.java
@@ -21,21 +21,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package org.incendo.cloud.fabric.internal;
+package org.incendo.cloud.minecraft.modded.internal;
 
+import java.util.Objects;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.ChatType;
 import net.kyori.adventure.chat.SignedMessage;
-import net.kyori.adventure.platform.fabric.impl.NonWrappingComponentSerializer;
+import net.kyori.adventure.platform.modcommon.impl.NonWrappingComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper;
 import org.incendo.cloud.minecraft.signed.SignedString;
 
 @API(status = API.Status.INTERNAL)
-public final class FabricSignedStringFactory implements ModdedSignedStringMapper.SignedStringFactory {
+public final class ModdedSignedStringFactory implements ModdedSignedStringMapper.SignedStringFactory {
+
+    /**
+     * Creates a new {@link ModdedSignedStringFactory}.
+     */
+    public ModdedSignedStringFactory() {
+        // Trigger service load failure when this isn't present
+        Objects.requireNonNull(NonWrappingComponentSerializer.class.getName());
+    }
+
     @Override
     public SignedString create(final String str, final PlayerChatMessage signedMessage) {
         return new SignedStringImpl(str, signedMessage);

--- a/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringMapper.java
+++ b/cloud-minecraft-modded-common/src/main/java/org/incendo/cloud/minecraft/modded/internal/ModdedSignedStringMapper.java
@@ -49,7 +49,7 @@ public final class ModdedSignedStringMapper implements SignedStringMapper {
      * Creates a new mapper.
      */
     public ModdedSignedStringMapper() {
-        this.factory = Services.service(SignedStringFactory.class)
+        this.factory = Services.serviceWithFallback(SignedStringFactory.class)
             .orElseThrow(() -> new IllegalStateException("Could not locate " + SignedStringFactory.class));
     }
 
@@ -102,5 +102,13 @@ public final class ModdedSignedStringMapper implements SignedStringMapper {
          * @return new signed string
          */
         SignedString create(String str, PlayerChatMessage signedMessage);
+    }
+
+    public static final class FallbackSignedStringFactory implements SignedStringFactory, Services.Fallback {
+
+        @Override
+        public SignedString create(final String str, final PlayerChatMessage signedMessage) {
+            return SignedString.unsigned(str);
+        }
     }
 }

--- a/cloud-minecraft-modded-common/src/main/resources/META-INF/services/org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper$SignedStringFactory
+++ b/cloud-minecraft-modded-common/src/main/resources/META-INF/services/org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper$SignedStringFactory
@@ -1,0 +1,2 @@
+org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringFactory
+org.incendo.cloud.minecraft.modded.internal.ModdedSignedStringMapper$FallbackSignedStringFactory

--- a/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/CloudNeoForgeEntrypoint.java
+++ b/cloud-neoforge/src/main/java/org/incendo/cloud/neoforge/CloudNeoForgeEntrypoint.java
@@ -68,7 +68,7 @@ public final class CloudNeoForgeEntrypoint {
      */
     public CloudNeoForgeEntrypoint(final IEventBus modBus) {
         if (ModList.get().isLoaded("adventure_platform_neoforge")) {
-            NeoForge.EVENT_BUS.addListener(EventPriority.HIGHEST, (ServerStartingEvent event) -> {
+            NeoForge.EVENT_BUS.addListener((ServerStartingEvent event) -> {
                 AdventureSupport.get().setupServer(event.getServer());
             });
             NeoForge.EVENT_BUS.addListener((ServerStoppedEvent event) -> {

--- a/cloud-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/cloud-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -27,5 +27,11 @@ versionRange = "[1.20.5,)"
 ordering = "NONE"
 side = "BOTH"
 
+[[dependencies.cloud]]
+modId = "adventure_platform_neoforge"
+type = "optional"
+ordering = "AFTER"
+side = "BOTH"
+
 [[mixins]]
 config = "cloud.mixins.json"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ fabricApi = "0.110.0+1.21.3"
 fabricPermissionsApi = "0.3.3"
 neoforge = "21.3.56"
 neoform = "1.21.3-20241023.131943"
+adventureMod = "6.1.0"
 
 [libraries]
 cloud-build-logic = { module = "org.incendo:cloud-build-logic", version.ref = "cloud-build-logic" }
@@ -31,7 +32,8 @@ geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = 
 cloud-brigadier = { module = "org.incendo:cloud-brigadier", version.ref = "cloudMinecraft" }
 cloud-minecraft-signed-arguments = { module = "org.incendo:cloud-minecraft-signed-arguments", version.ref = "cloudMinecraft" }
 adventureApi = { group = "net.kyori", name = "adventure-api", version = "4.15.0" }
-adventureFabric = "net.kyori:adventure-platform-fabric:5.13.0"
+adventureMod = { module = "net.kyori:adventure-platform-mod-shared", version.ref = "adventureMod" }
+adventureFabric = { module = "net.kyori:adventure-platform-fabric", version.ref = "adventureMod" }
 
 immutables = { group = "org.immutables", name = "value", version.ref = "immutables" }
 immutablesAnnotate = { group = "org.immutables", name = "annotate", version.ref = "immutables" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = 
 cloud-brigadier = { module = "org.incendo:cloud-brigadier", version.ref = "cloudMinecraft" }
 cloud-minecraft-signed-arguments = { module = "org.incendo:cloud-minecraft-signed-arguments", version.ref = "cloudMinecraft" }
 cloud-minecraft-extras = { module = "org.incendo:cloud-minecraft-extras", version.ref = "cloudMinecraft" }
-adventureApi = { group = "net.kyori", name = "adventure-api", version = "4.15.0" }
+adventureApi = { group = "net.kyori", name = "adventure-api", version = "4.17.0" }
 adventureMod = { module = "net.kyori:adventure-platform-mod-shared", version.ref = "adventureMod" }
 adventureFabric = { module = "net.kyori:adventure-platform-fabric", version.ref = "adventureMod" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ cloud-services = { module = "org.incendo:cloud-services", version.ref = "cloud" 
 geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = "geantyref" }
 cloud-brigadier = { module = "org.incendo:cloud-brigadier", version.ref = "cloudMinecraft" }
 cloud-minecraft-signed-arguments = { module = "org.incendo:cloud-minecraft-signed-arguments", version.ref = "cloudMinecraft" }
+cloud-minecraft-extras = { module = "org.incendo:cloud-minecraft-extras", version.ref = "cloudMinecraft" }
 adventureApi = { group = "net.kyori", name = "adventure-api", version = "4.15.0" }
 adventureMod = { module = "net.kyori:adventure-platform-mod-shared", version.ref = "adventureMod" }
 adventureFabric = { module = "net.kyori:adventure-platform-fabric", version.ref = "adventureMod" }


### PR DESCRIPTION
Drops support for adventure-platform-fabric 5.x, adds support for adventure-platform-mod 6.x

Should gracefully do nothing/return unsigned strings with 5.x

Implement ComponentMessageThrowable conversions and fix registry aware signed string conversions