### PR TITLE
Update fabric.mod.json and neoforge.mods.toml to match the version supported

### DIFF
--- a/cloud-fabric/src/main/resources/fabric.mod.json
+++ b/cloud-fabric/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
     "fabric-command-api-v2": "*",
     "fabric-networking-api-v1": "*",
     "fabric-lifecycle-events-v1": "*",
-    "minecraft": ">1.18.2"
+    "minecraft": ">1.21.6"
   }
 }

--- a/cloud-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/cloud-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,14 +16,14 @@ displayTest = "IGNORE_ALL_VERSION"
 [[dependencies.cloud]]
 modId = "neoforge"
 type = "required"
-versionRange = "[20.5,)"
+versionRange = "[21.6,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.cloud]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.20.5,)"
+versionRange = "[1.21.6,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Causes issues if you attempt to launch on lower versions, ideally Fabric and NeoForge should catch this beforehand, but can only do so with the right metadata.