### PR TITLE
fix: expose Immutables annotations to consumers

### DIFF
--- a/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
@@ -36,6 +36,7 @@ cloudSpotless {
 dependencies {
     checkstyle(libs.stylecheck)
     errorprone(libs.errorproneCore)
-    compileOnly(libs.bundles.immutables)
-    annotationProcessor(libs.bundles.immutables)
+    compileOnlyApi(libs.immutablesValueAnnotations)
+    compileOnlyApi(libs.immutablesAnnotate)
+    annotationProcessor(libs.immutablesValue)
 }

--- a/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
@@ -25,4 +25,6 @@ javadocLinks {
     override(libs.fabricLoader, "https://maven.fabricmc.net/docs/fabric-loader-{version}")
     excludes.add("net.fabricmc.fabric-api:")
     defaultJavadocProvider = "https://www.javadocs.dev/{group}/{name}/{version}"
+    exclude(libs.immutablesValueAnnotations)
+    exclude(libs.immutablesAnnotate)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,8 @@ adventureApi = { group = "net.kyori", name = "adventure-api", version.ref = "adv
 adventureMod = { module = "net.kyori:adventure-platform-mod-shared", version.ref = "adventureMod" }
 adventureFabric = { module = "net.kyori:adventure-platform-fabric", version.ref = "adventureMod" }
 
-immutables = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValue = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValueAnnotations = { group = "org.immutables", name = "value-annotations", version.ref = "immutables" }
 immutablesAnnotate = { group = "org.immutables", name = "annotate", version.ref = "immutables" }
 
 minecraft = { group = "com.mojang", name = "minecraft", version.ref = "minecraft" }
@@ -52,6 +53,3 @@ zNeoForge = { module = "net.neoforged:neoforge", version.ref = "neoforge" }
 cloud-buildLogic-spotless = { id = "org.incendo.cloud-build-logic.spotless", version.ref = "cloud-build-logic" }
 cloud-buildLogic-rootProject-publishing = { id = "org.incendo.cloud-build-logic.publishing.root-project", version.ref = "cloud-build-logic" }
 cloud-buildLogic-rootProject-spotless = { id = "org.incendo.cloud-build-logic.spotless.root-project", version.ref = "cloud-build-logic" }
-
-[bundles]
-immutables = ["immutables", "immutablesAnnotate"]


### PR DESCRIPTION
Publish the lightweight value and annotate artifacts on consumers' compile classpaths while keeping the full Immutables processor isolated to annotation processing.

Exclude these artifacts from external Javadoc linking because they do not publish the required element-list or package-list files.

Fixes missing annotation warnings for consumers.

Ports Incendo/cloud-minecraft#170.